### PR TITLE
Change email sender to include name; refactoring of email module; unit tests

### DIFF
--- a/goemail.py
+++ b/goemail.py
@@ -13,6 +13,8 @@ import pickle
 from webapp2_extras import i18n
 from webapp2_extras.i18n import gettext as _
 
+_admin_email_address = 'Gig-o-Matic <gigomatic.superuser@gmail.com>'
+
 def _send_admin_mail(to, subject, body, html=None, reply_to=None):
     valid_address = r"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$"
     if (not mail.is_email_valid(to)) or (re.match(valid_address, to.lower()) is None):
@@ -20,7 +22,7 @@ def _send_admin_mail(to, subject, body, html=None, reply_to=None):
         return False
 
     message = mail.EmailMessage()
-    message.sender = 'Gig-o-Matic <gigomatic.superuser@gmail.com>'
+    message.sender = _admin_email_address
     message.to = to
     message.subject = subject
     message.body = body
@@ -245,11 +247,11 @@ def send_the_pending_email(the_req, the_email_address, the_confirm_link):
                             _('confirm_email_address_email').format(the_confirm_link))
 
 def notify_superuser_of_archive(the_num):
-    return _send_admin_mail('gigomatic.superuser@gmail.com', 'Gig-o-Matic Auto-Archiver'
+    return _send_admin_mail(_admin_email_address, 'Gig-o-Matic Auto-Archiver'
                            "Yo! The Gig-o-Matic archived {0} gigs last night.".format(the_num))
 
 def notify_superuser_of_old_tokens(the_num):
-    return _send_admin_mail('gigomatic.superuser@gmail.com', 'Gig-o-Matic Old Tokens',
+    return _send_admin_mail(_admin_email_address, 'Gig-o-Matic Old Tokens',
                            "Yo! The Gig-o-Matic found {0} old signup tokens last night.".format(the_num))
 
 def send_band_request_email(the_email_address, the_name, the_info):
@@ -266,4 +268,4 @@ Enjoy,
 Team Gig-o-Matic
 
     """.format(the_email_address, the_name, the_info)
-    return _send_admin_mail('gigomatic.superuser@gmail.com', 'Gig-o-Matic New Band Request', body)
+    return _send_admin_mail(_admin_email_address, 'Gig-o-Matic New Band Request', body)

--- a/goemail.py
+++ b/goemail.py
@@ -9,14 +9,22 @@ import assoc
 import logging
 import re
 import pickle
+import os
 
 from webapp2_extras import i18n
 from webapp2_extras.i18n import gettext as _
 
-_admin_email_address = 'Gig-o-Matic <gigomatic.superuser@gmail.com>'
+# The MailServiceStub class used by dev_appserver can't handle a sender address that's more
+# than a raw email address, but production GAE doesn't have this limitation.
+if os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/'):
+    _admin_email_address = 'Gig-o-matic <gigomatic.superuser@gmail.com>'
+else:
+    _admin_email_address = 'gigomatic.superuser@gmail.com'
 
 def _send_admin_mail(to, subject, body, html=None, reply_to=None):
-    valid_address = r"^[_a-z0-9-]+(\.[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$"
+    # + and . are allowed in username, and . in the domain name, but neither can be
+    # the leading character. Alphanumerics, - and _ are allowed anywhere.
+    valid_address = r"^[_a-z0-9-]+((\.|\+)[_a-z0-9-]+)*@[a-z0-9-]+(\.[a-z0-9-]+)*(\.[a-z]{2,4})$"
     if (not mail.is_email_valid(to)) or (re.match(valid_address, to.lower()) is None):
         logging.error("invalid recipient address '{0}'".format(to))
         return False

--- a/member.py
+++ b/member.py
@@ -21,7 +21,6 @@ import plan
 import goemail
 import assoc
 import login
-import forum
 import datetime
 import lang
 from colors import colors
@@ -190,6 +189,7 @@ class Member(webapp2_extras.appengine.auth.models.User):
 
     @classmethod
     def get_forums(cls, req, the_member_key):
+        import forum
         """ check to see if this is in the session - if so, just use it """
         if 'member_forumlist' in req.session.keys() and not req.member_cache_is_dirty(the_member_key):
             the_forums = req.session['member_forumlist']

--- a/tests/mail_tests.py
+++ b/tests/mail_tests.py
@@ -51,6 +51,7 @@ class MailTestCase(unittest.TestCase):
 
     def assertWellFormedAndContainsText(self, recipient, text):
         message = self._get_single_message()
+        self.assertEqual(message.sender, goemail._admin_email_address)
         self.assertEqual(message.to, recipient)
         self.assertNotEmpty(message.subject)
         self.assertRegexpMatches(message.body.payload, text)
@@ -96,9 +97,28 @@ class MailTestCase(unittest.TestCase):
         self.assertRegexpMatches(message.body.payload, "Parade")
 
     def test_new_member_email(self):
-        the_band, the_member = self._create_test_band_with_member(True)
+        the_band, the_member = self._create_test_band_with_member()
         goemail.send_new_member_email(the_band, the_member)
         self.assertWellFormedAndContainsText(self.TEST_RECIPIENT, the_member.name)
+
+    def test_new_band_via_invite_email(self):
+        the_band, the_member = self._create_test_band_with_member()
+        goemail.send_new_band_via_invite_email(self.request_stub, the_band, the_member)
+        self.assertWellFormedAndContainsText(self.TEST_RECIPIENT, the_band.name)
+
+    def test_gigo_invite_email(self):
+        the_band, the_member = self._create_test_band_with_member()
+        goemail.send_gigo_invite_email(self.request_stub, the_band, the_member, self.TEST_URL)
+
+        message = self._get_single_message()
+        self.assertEqual(message.to, self.TEST_RECIPIENT)
+        self.assertNotEmpty(message.subject)
+        self.assertRegexpMatches(message.body.payload, self.TEST_BAND)
+        self.assertRegexpMatches(message.body.payload, self.TEST_URL)
+
+    def test_user_confirm_email(self):
+        goemail.send_the_pending_email(self.request_stub, self.TEST_RECIPIENT, self.TEST_URL)
+        self.assertWellFormedAndContainsText(self.TEST_RECIPIENT, self.TEST_URL)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/mail_tests.py
+++ b/tests/mail_tests.py
@@ -1,0 +1,104 @@
+import unittest
+import webapp2
+import goemail
+import main
+import band
+import member
+import assoc
+import gig
+import crypto_db
+
+from google.appengine.ext import testbed
+
+class MailTestCase(unittest.TestCase):
+    TEST_RECIPIENT = 'alice@example.com'
+    TEST_BAND = 'Wild Rumpus'
+    TEST_URL = 'http://example.com'
+
+    # Needed to get webapp2 to use a WSGIApplication application instance,
+    # which is easier to configure in setUp().
+    webapp2._local = None
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_mail_stub()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+        self.mail_stub = self.testbed.get_stub(testbed.MAIL_SERVICE_NAME)
+
+        crypto_db.set_cryptokey('dead0000dead0000')
+
+        # Need to set up a global application and Request instance for
+        # the i18n module to work. There's probably a more elegant way
+        # of doing this.
+        self.request_stub = webapp2.Request.blank("/")
+        self.request_stub.user = None
+        self.request_stub.app = main.APPLICATION
+        webapp2.WSGIApplication.app = main.APPLICATION
+        webapp2.get_app().set_globals(main.APPLICATION, self.request_stub)
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def assertNotEmpty(self, obj):
+        self.assertTrue(obj is not None and len(obj) > 0)
+
+    def _get_single_message(self):
+        messages = self.mail_stub.get_sent_messages(to=self.TEST_RECIPIENT)
+        self.assertEqual(len(messages), 1)
+        return messages[0]
+
+    def assertWellFormedAndContainsText(self, recipient, text):
+        message = self._get_single_message()
+        self.assertEqual(message.to, recipient)
+        self.assertNotEmpty(message.subject)
+        self.assertRegexpMatches(message.body.payload, text)
+
+    def test_registration_email(self):
+        goemail.send_registration_email(self.request_stub, self.TEST_RECIPIENT, self.TEST_URL)
+        self.assertWellFormedAndContainsText(self.TEST_RECIPIENT, self.TEST_URL)
+
+    def test_band_accepted_email(self):
+        the_band = band.new_band(self.TEST_BAND)
+        goemail.send_band_accepted_email(self.request_stub, self.TEST_RECIPIENT, the_band)
+
+        self.assertWellFormedAndContainsText(self.TEST_RECIPIENT, self.TEST_BAND)
+
+    def test_forgot_email(self):
+        goemail.send_forgot_email(self.request_stub, self.TEST_RECIPIENT, self.TEST_URL)
+        self.assertWellFormedAndContainsText(self.TEST_RECIPIENT, self.TEST_URL)
+
+    def _create_test_band_with_member(self, member_is_admin = True):
+        the_band = band.new_band(self.TEST_BAND)
+        (member_created, the_member) = member.create_new_member(self.TEST_RECIPIENT, 'Alice', 'password')
+        self.assertTrue(member_created)
+
+        membership = assoc.Assoc();
+        membership.band = the_band.key
+        membership.member = the_member.key
+        if member_is_admin:
+            membership.is_band_admin = True
+        membership.put()
+
+        return (the_band, the_member)
+
+    def test_newgig_email(self):
+        # Create band with member and instantiate a gig
+        the_band, the_member = self._create_test_band_with_member()
+        the_gig = gig.new_gig(the_band, "Parade", the_member.key)
+
+        goemail.send_newgig_email(the_member, the_gig, the_band, self.TEST_URL, True, True)
+        message = self._get_single_message()
+        self.assertEqual(message.to, self.TEST_RECIPIENT)
+        self.assertNotEmpty(message.subject)
+        self.assertRegexpMatches(message.body.payload, self.TEST_URL)
+        self.assertRegexpMatches(message.body.payload, "Parade")
+
+    def test_new_member_email(self):
+        the_band, the_member = self._create_test_band_with_member(True)
+        goemail.send_new_member_email(the_band, the_member)
+        self.assertWellFormedAndContainsText(self.TEST_RECIPIENT, the_member.name)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The primary thing I wanted to do here was to change the from header on outgoing emails to 'Gig-o-Matic <gigomatic.superuser@gmail.com>', since it's been bugging me for a while that it's a raw email address without a sender name. The refactoring and unit tests happened 'cause I can't help myself with redundant code.