### PR TITLE
Add 'get current member info' capability to the REST API

### DIFF
--- a/main.py
+++ b/main.py
@@ -72,6 +72,7 @@ else:
         webapp2.Route('/api/gig/<gig_id:.+>', gig_handlers.RestEndpoint),
 
         webapp2.Route('/api/member/<member_id:.+>', member_handlers.RestEndpoint),
+        webapp2.Route('/api/member', member_handlers.RestEndpoint),
 
 
         # webapp2.Route('/apiX/<endpoint><:/*><values:.*>', restify.Endpoint),

--- a/member.py
+++ b/member.py
@@ -472,5 +472,7 @@ def make_member_cal_dirty(the_member_key):
 
 def rest_member_info(the_member, include_id=True):
     obj = { k:getattr(the_member,k) for k in ['display_name'] }
+    if include_id:
+        obj["id"] = the_member.key.urlsafe()
     return obj
 

--- a/member_handlers.py
+++ b/member_handlers.py
@@ -772,12 +772,16 @@ class RestEndpoint(BaseHandler):
     @rest_user_required
     @CSOR_Jsonify
     def get(self, *args, **kwargs):
-        try:
-            member_id = kwargs["member_id"]
-            the_member = member.member_key_from_urlsafe(member_id).get()
-        except:
-            self.abort(404)
+        if "member_id" in kwargs:
+            include_id=False
+            try:
+                member_id = kwargs["member_id"]
+                the_member = member.member_key_from_urlsafe(member_id).get()
+                # are we authorized to see the member? TODO
+            except:
+                self.abort(404)
+        else:
+            include_id=True
+            the_member = self.user
 
-        # are we authorized to see the member? TODO
-
-        return member.rest_member_info(the_member, include_id=False)
+        return member.rest_member_info(the_member, include_id)


### PR DESCRIPTION
We didn't have a way to find our userid or name for the logged-in
user in the API. I could definitely have extended the data here to
be even more complete, but this is sufficient for my requirements
today.

Testing:

* It properly returns the logged-in user with the added 'id' field
  when called without a trailing slash
* It also still returns a requested member when passed the trailing
  slash and a full (url safe) member id