### PR TITLE
Fix Initial Captcha Requirement

### DIFF
--- a/templates/signup.html
+++ b/templates/signup.html
@@ -1,7 +1,7 @@
 {% extends 'go2base.html' %}
 
 {% block headcontent %}
-<script src="https://www.google.com/recaptcha/api.js"></script>
+{% if site_key %}<script src="https://www.google.com/recaptcha/api.js"></script>{% endif %}
 {% endblock headcontent %}
 
 {% block title %}{% trans %}Register!{% endtrans %}{% endblock title %}
@@ -57,7 +57,7 @@ class="landingwrap"
                 </div>
                 <div>
                     <button type="submit" 
-                            class="btn btn-primary g-recaptcha" 
+                            class="btn btn-primary {% if site_key %}g-recaptcha{% endif %}" 
                             data-sitekey="{{ site_key }}" 
                             data-callback='onSubmit' 
                             data-action='submit'>{% trans %}Sign me up!{% endtrans %}</button>


### PR DESCRIPTION
There is a 'open the crate with the enclosed crowbar' style bug
in the current code which requires an admin password to set the
captcha keys, but requires captcha keys to create a new user.

This patch removes the captcha code from the sign-in page as long
as captcha keys are unset, which lets a deployment choose if/when
they will add captcha to the site, but, importantly, fixes the
bootstrap issue.

Testing:

Validated that this now works without a captcha key.

Note: As I don't have captcha creds, I've not tested that this
will work *with* captcha keys, so this is to be tested.